### PR TITLE
Remove expand filesystem prompt

### DIFF
--- a/automated_install/auto-install.sh
+++ b/automated_install/auto-install.sh
@@ -96,10 +96,7 @@ verifyFreeDiskSpace() {
     echo ":: Insufficient Disk Space!"
     echo ":: Your system appears to be low on disk space. ${package_name} recommends a minimum of $required_free_kilobytes KB."
     echo ":: You only have ${existing_free_kilobytes} KB free."
-    echo ":: If this is a new install you may need to expand your disk."
-    echo ":: Try running 'sudo raspi-config', and choose the 'expand file system option'"
-    echo ":: After rebooting, run this installation again. (${install_curl_command})"
-
+    echo ":: After freeing up space, run this installation script again. (${install_curl_command})"
     echo "Insufficient free space, exiting..."
     exit 1
   fi


### PR DESCRIPTION
This removes the 'expand filesystem' lines in the installer. Closes #29 

I didn't remove the ssh key prompt as the issue dictates- imho, that prompt only flashes if that key is actually found, and is probably worth the extra 300 bytes of code 'just in case' someone still has an older version floating around that they try to install on. Overly cautious/borderline paranoid, but as it doesn't show to the user, I think its ok to leave. My two cents!