### PR TITLE
Remove auto-sudo functionality

### DIFF
--- a/automated_install/auto-install.sh
+++ b/automated_install/auto-install.sh
@@ -153,7 +153,6 @@ launchInstall() {
 ### Now, for the main event...
 #######
 verifyRunAsRoot
-exit
 verifyFreeDiskSpace
 getAptPackages
 cloneFromGit

--- a/automated_install/auto-install.sh
+++ b/automated_install/auto-install.sh
@@ -52,31 +52,20 @@ die () {
 #######
 verifyRunAsRoot() {
     # verifyRunAsRoot does two things - First, it checks if the script was run by a root user. Assuming it wasn't,
-    # then it attempts to relaunch itself as root.
-
+    # it prompts the user to relaunch as root.
 
     if [[ ${EUID} -eq 0 ]]; then
         echo "::: This script was launched as root. Continuing installation."
     else
-        echo "::: This script was called without root privileges. It installs and updates several packages, and the"
-        echo "::: script it calls within ${tools_name} creates user accounts and updates  system settings. To"
-        echo "::: continue this script will now attempt to use 'sudo' to relaunch itself as root. Please check"
-        echo "::: the contents of this script (as well as the install script within ${tools_name} for any concerns"
-        echo "::: with this requirement. Please be sure to access this script (and ${tools_name}) from a trusted"
-        echo "::: source."
+        echo "::: This script was called without root privileges, which are required as it installs and updates several"
+        echo "::: packages, and the script it calls within ${tools_name} creates user accounts and updates system"
+        echo "::: settings. To continue, this script must launched using the 'sudo' command to run as root. Please check"
+        echo "::: the contents of this script (as well as the install script within ${tools_name}) for any concerns with"
+        echo "::: this requirement. Please be sure to access this script (and ${tools_name}) from a trusted source."
         echo ":::"
-
-        if command -v sudo &> /dev/null; then
-            # TODO - Make this require user confirmation before continuing
-            echo "::: This script will now attempt to relaunch using sudo."
-            exec curl -L $install_curl_url | sudo bash "$@"
-            exit $?
-        else
-            echo "::: The sudo utility does not appear to be available on this system, and thus installation cannot continue."
-            echo "::: Please run this script as root and it will be automatically installed."
-            echo "::: You should be able to do this by running '${install_curl_command}'"
-            exit 1
-        fi
+        echo "::: To re-run this script with sudo permissions, type:"
+        echo "::: sudo $0"
+        exit 1
     fi
 
 }
@@ -164,8 +153,8 @@ launchInstall() {
 ### Now, for the main event...
 #######
 verifyRunAsRoot
+exit
 verifyFreeDiskSpace
 getAptPackages
 cloneFromGit
 launchInstall
-


### PR DESCRIPTION
Hi @thorrak 

I see from the comments in your script you were already thinking along these lines. I'd like suggest removing the auto-sudo functionality you have built in to the install script completely, rather than just adding a prompt to the user. Especially with raspbian, where the default 'pi' user doesn't have to enter a password at all, the auto-restart with sudo could be considered poor security by some. The ``curl|bash`` install path has had many a long spirited discussion as to whether it is a good practice or not, but using sudo bash is probably something that everyone can agree should be avoided.

In addition to this patch, I would recommend updating documentation to perhaps suggest using something like this to install from:
``curl -Lo ft.sh install.fermentrack.com; bash tmp.sh``
This will fail, of course, but it will a) download a permanent copy of the script to the user's local storage and then b) prompt the user to re-run it with sudo, after inspecting it if they so choose.

The worry here is that, should your fermentrack.com webserver become compromised in some way, code could be added that would be auto-run with root privileges by unsuspecting users. While I still personally believe most users will not, this at least gives the user a chance to inspect or understand what is happening, before it happens. 

One more step to increase security with this method would be to post the SHA hashes to a server that does not serve the install script (like in the docs on readthedocs.org, perhaps) and encourage users run a sha hash of the download script, and then compare it to the docs.

These are just a few thoughts- its not my project, so I don't know what extra levels you would want to go towards. I'd be happy to implement any of your thoughts. 

Are you on IRC, by any chance, or can pass an email? I have a few other comments I'd like to share offline with you, if possible. Thanks!