### PR TITLE
Remove SVN usage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,7 +329,14 @@ get_files_from_main_repo() {
   fi
 
   # Download the relevant files from GitHub
-  svn export https://github.com/thorrak/fermentrack/branches/master/compose &>> install.log
+#  svn export https://github.com/thorrak/fermentrack/branches/master/compose &>> install.log
+
+  git clone https://github.com/thorrak/fermentrack.git
+  cd fermentrack
+  mv -rf compose ..
+  cd ..
+  rm -rf fermentrack
+
 
   cp sample.docker-compose.yml docker-compose.yml
   mkdir -p envs

--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,7 @@ get_files_from_main_repo() {
 
   git clone https://github.com/thorrak/fermentrack.git &>> install.log
   cd fermentrack
-  mv -compose ..
+  mv compose ..
   cd ..
   rm -rf fermentrack
 

--- a/install.sh
+++ b/install.sh
@@ -331,9 +331,9 @@ get_files_from_main_repo() {
   # Download the relevant files from GitHub
 #  svn export https://github.com/thorrak/fermentrack/branches/master/compose &>> install.log
 
-  git clone https://github.com/thorrak/fermentrack.git
+  git clone https://github.com/thorrak/fermentrack.git &>> install.log
   cd fermentrack
-  mv -rf compose ..
+  mv -compose ..
   cd ..
   rm -rf fermentrack
 
@@ -377,9 +377,9 @@ setup_postgres_env() {
 
 setup_tiltbridge_jr_env() {
   if [ -f "./envs/tiltbridge-jr" ]; then
-    printinfo "${PACKAGE_NAME} TiltBridge Junior environment configuration already exists at ./envs/tiltbridge-jr"
+    printinfo "TiltBridge Junior environment configuration already exists at ./envs/tiltbridge-jr"
   else
-    printinfo "Creating ${PACKAGE_NAME} TiltBridge Junior environment configuration at ./envs/tiltbridge-jr"
+    printinfo "Creating TiltBridge Junior environment configuration at ./envs/tiltbridge-jr"
     cp sample_envs/tiltbridge-jr envs/tiltbridge-jr
     sed -i "s+FERMENTRACK_LEGACY_TARGET_ENABLED=false+FERMENTRACK_LEGACY_TARGET_ENABLED=true+g" envs/tiltbridge-jr
   fi


### PR DESCRIPTION
GitHub no longer supports the use of subversion, so one of the tricks taht I used to make installs slightly faster no longer works. This replaces the use of subversion with git.